### PR TITLE
Thread-safety workaround 

### DIFF
--- a/include/kinetic/blocking_kinetic_connection.h
+++ b/include/kinetic/blocking_kinetic_connection.h
@@ -22,6 +22,7 @@
 #define KINETIC_CPP_CLIENT_BLOCKING_KINETIC_CONNECTION_H_
 
 #include <memory>
+#include <mutex>
 
 #include "kinetic/nonblocking_kinetic_connection.h"
 #include "kinetic/status.h"
@@ -41,6 +42,9 @@ class KeyRangeIterator;
 class BlockingCallbackState;
 
 class BlockingKineticConnection {
+    private:
+    std::mutex force_single_thread;
+
     public:
     /// Takes ownership of the given NonblockingKineticConnection
     /// @param[in] nonblocking_connection   The underlying connection that will be used

--- a/src/main/blocking_kinetic_connection.cc
+++ b/src/main/blocking_kinetic_connection.cc
@@ -398,6 +398,7 @@ KineticStatus BlockingKineticConnection::P2PPush(
 KineticStatus BlockingKineticConnection::RunOperation(
         shared_ptr<BlockingCallbackState> callback,
         HandlerKey handler_key) {
+    std::lock_guard<std::mutex> lock(force_single_thread);
     fd_set read_fds, write_fds;
     int nfds;
 


### PR DESCRIPTION
via enforcing single-threaded execution even in multithreaded environments. Not a final solution. 
