### PR TITLE
Features/asokvad 63

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ ExternalProject_add(
     INSTALL_COMMAND ""
 )
 
-set(KINETIC_PROTO_VERSION "6dcceb871d03ae8b727d48ddcc88053d9e9d6874")
-set(KINETIC_PROTO_MD5 "de61424f3340a6216a3576c1997f2f2c")
+set(KINETIC_PROTO_VERSION "2.0.1")
+set(KINETIC_PROTO_MD5 "1505fab102afc04994932c7c1406a697")
 
 ExternalProject_add(
     kinetic-proto

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo contains code for producing C and C++ kinetic clients.
 
 Protocol Version
 =================
-The client is using version `2.0.0` of the [Kinetic-Protocol](https://github.com/Seagate/kinetic-protocol/releases/tag/2.0.0).
+The client is using version `2.0.1` of the [Kinetic-Protocol](https://github.com/Seagate/kinetic-protocol/releases/tag/2.0.1).
 
 
 Dependencies

--- a/include/kinetic/drive_log.h
+++ b/include/kinetic/drive_log.h
@@ -26,8 +26,8 @@
 namespace kinetic {
 
 typedef struct {
-    uint64_t remaining_bytes;
-    uint64_t total_bytes;
+    uint64_t nominal_capacity_in_bytes;
+    float portion_full;
 } Capacity;
 
 typedef struct {

--- a/src/main/nonblocking_kinetic_connection.cc
+++ b/src/main/nonblocking_kinetic_connection.cc
@@ -148,8 +148,8 @@ void GetLogHandler::Handle(const Message& response, unique_ptr<const string> val
     drive_log->configuration.tls_port = configuration.tlsport();
 
     auto capacity = getlog.capacity();
-    drive_log->capacity.remaining_bytes = capacity.remaining();
-    drive_log->capacity.total_bytes = capacity.total();
+    drive_log->capacity.nominal_capacity_in_bytes = capacity.nominalcapacityinbytes();
+    drive_log->capacity.portion_full = capacity.portionfull();
 
     auto limits = getlog.limits();
     drive_log->limits.max_key_size = limits.maxkeysize();


### PR DESCRIPTION
- Updated client to use new protocol version
- Exposed limits reporting 
- Updated Capacity reporting.

Note: This is ahead of kineticd, which doesn't have the Capacity feature yet. GetLogs will fail against kineticd master.
