### PR TITLE
Added explicit flush to blocking and nonblocking API.

### DIFF
--- a/include/kinetic/blocking_kinetic_connection.h
+++ b/include/kinetic/blocking_kinetic_connection.h
@@ -134,6 +134,8 @@ class BlockingKineticConnection : public BlockingKineticConnectionInterface {
     KineticStatus P2PPush(const shared_ptr<const P2PPushRequest> push_request,
             unique_ptr<vector<KineticStatus>>& operation_statuses);
 
+    KineticStatus Flush();
+
     KineticStatus SetClusterVersion(int64_t cluster_version);
     KineticStatus UpdateFirmware(const shared_ptr<const string> new_firmware);
     KineticStatus SetACLs(const shared_ptr<const list<ACL>> acls);

--- a/include/kinetic/blocking_kinetic_connection_interface.h
+++ b/include/kinetic/blocking_kinetic_connection_interface.h
@@ -117,6 +117,7 @@ class BlockingKineticConnectionInterface {
             unique_ptr<vector<KineticStatus>>& operation_statuses) = 0;
     virtual KineticStatus P2PPush(const shared_ptr<const P2PPushRequest> push_request,
             unique_ptr<vector<KineticStatus>>& operation_statuses) = 0;
+    virtual KineticStatus Flush() = 0;
 
     virtual KineticStatus SetClusterVersion(int64_t cluster_version) = 0;
     virtual KineticStatus UpdateFirmware(const shared_ptr<const string> new_firmware) = 0;

--- a/include/kinetic/nonblocking_kinetic_connection.h
+++ b/include/kinetic/nonblocking_kinetic_connection.h
@@ -68,6 +68,7 @@ class NonblockingKineticConnection : public NonblockingKineticConnectionInterfac
             const shared_ptr<P2PPushCallbackInterface> callback);
     HandlerKey GetLog(const shared_ptr<GetLogCallbackInterface> callback);
     HandlerKey GetLog(const vector<Command_GetLog_Type>& types, const shared_ptr<GetLogCallbackInterface> callback);
+    HandlerKey Flush(const shared_ptr<SimpleCallbackInterface> callback);
 
     HandlerKey UpdateFirmware(const shared_ptr<const string> new_firmware, const shared_ptr<SimpleCallbackInterface> callback);
     HandlerKey SetClusterVersion(int64_t new_cluster_version, const shared_ptr<SimpleCallbackInterface> callback);

--- a/include/kinetic/nonblocking_kinetic_connection_interface.h
+++ b/include/kinetic/nonblocking_kinetic_connection_interface.h
@@ -285,6 +285,7 @@ public:
     virtual HandlerKey GetLog(const shared_ptr<GetLogCallbackInterface> callback) = 0;
     virtual HandlerKey GetLog(const vector<Command_GetLog_Type>& types,
             const shared_ptr<GetLogCallbackInterface> callback) = 0;
+    virtual HandlerKey Flush(const shared_ptr<SimpleCallbackInterface> callback) = 0;
 
     virtual HandlerKey UpdateFirmware(const shared_ptr<const string> new_firmware,
         const shared_ptr<SimpleCallbackInterface> callback) = 0;

--- a/include/kinetic/threadsafe_blocking_kinetic_connection.h
+++ b/include/kinetic/threadsafe_blocking_kinetic_connection.h
@@ -134,6 +134,8 @@ class ThreadsafeBlockingKineticConnection : public BlockingKineticConnectionInte
       KineticStatus P2PPush(const shared_ptr<const P2PPushRequest> push_request,
               unique_ptr<vector<KineticStatus>>& operation_statuses);
 
+      KineticStatus Flush();
+
       KineticStatus SetClusterVersion(int64_t cluster_version);
       KineticStatus UpdateFirmware(const shared_ptr<const string> new_firmware);
       KineticStatus SetACLs(const shared_ptr<const list<ACL>> acls);

--- a/include/kinetic/threadsafe_nonblocking_connection.h
+++ b/include/kinetic/threadsafe_nonblocking_connection.h
@@ -74,6 +74,7 @@ public:
               const shared_ptr<P2PPushCallbackInterface> callback);
       HandlerKey GetLog(const shared_ptr<GetLogCallbackInterface> callback);
       HandlerKey GetLog(const vector<Command_GetLog_Type>& types, const shared_ptr<GetLogCallbackInterface> callback);
+      HandlerKey Flush(const shared_ptr<SimpleCallbackInterface> callback);
 
       HandlerKey UpdateFirmware(const shared_ptr<const string> new_firmware, const shared_ptr<SimpleCallbackInterface> callback);
       HandlerKey SetClusterVersion(int64_t new_cluster_version, const shared_ptr<SimpleCallbackInterface> callback);

--- a/src/integration_test/blocking_smoketest.cc
+++ b/src/integration_test/blocking_smoketest.cc
@@ -47,6 +47,8 @@ TEST_F(IntegrationTest, BlockingSmoketest) {
     ASSERT_TRUE(blocking_connection_->Put(make_shared<string>("key3"), make_shared<string>(""),
        WriteMode::IGNORE_VERSION, record3).ok());
 
+    ASSERT_TRUE(blocking_connection_->Flush().ok());
+
     KeyRangeIterator it = blocking_connection_->IterateKeyRange("key1", true, "key3", false, 1);
     ASSERT_EQ("key1", *it);
     ++it;

--- a/src/main/blocking_kinetic_connection.cc
+++ b/src/main/blocking_kinetic_connection.cc
@@ -294,6 +294,11 @@ KineticStatus BlockingKineticConnection::GetLog(const vector<Command_GetLog_Type
     return RunOperation(callback, nonblocking_connection_->GetLog(types, callback));
 }
 
+KineticStatus BlockingKineticConnection::Flush() {
+    auto callback = make_shared<SimpleCallback>();
+    return RunOperation(callback, nonblocking_connection_->Flush(callback));
+}
+
 KineticStatus BlockingKineticConnection::UpdateFirmware(const shared_ptr<const string>
         new_firmware) {
     auto callback = make_shared<SimpleCallback>();

--- a/src/main/nonblocking_kinetic_connection.cc
+++ b/src/main/nonblocking_kinetic_connection.cc
@@ -22,46 +22,7 @@
 
 namespace kinetic {
 
-using com::seagate::kinetic::client::proto::Command_MessageType_DELETE;
-using com::seagate::kinetic::client::proto::Command_MessageType_GET;
-using com::seagate::kinetic::client::proto::Command_MessageType_GETNEXT;
-using com::seagate::kinetic::client::proto::Command_MessageType_GETPREVIOUS;
-using com::seagate::kinetic::client::proto::Command_MessageType_GETKEYRANGE;
-using com::seagate::kinetic::client::proto::Command_MessageType_GETVERSION;
-using com::seagate::kinetic::client::proto::Command_MessageType_NOOP;
-using com::seagate::kinetic::client::proto::Command_MessageType_PUT;
-using com::seagate::kinetic::client::proto::Command_MessageType_SETUP;
-using com::seagate::kinetic::client::proto::Command_MessageType_GETLOG;
-using com::seagate::kinetic::client::proto::Command_MessageType_SECURITY;
-using com::seagate::kinetic::client::proto::Command_MessageType_PEER2PEERPUSH;
-using com::seagate::kinetic::client::proto::Command_MessageType_PINOP;
-using com::seagate::kinetic::client::proto::Command_Status_StatusCode_NOT_AUTHORIZED;
-using com::seagate::kinetic::client::proto::Command_Status_StatusCode_NOT_FOUND;
-using com::seagate::kinetic::client::proto::Command_Status_StatusCode_SUCCESS;
-using com::seagate::kinetic::client::proto::Command_GetLog_Type_UTILIZATIONS;
-using com::seagate::kinetic::client::proto::Command_GetLog_Type_TEMPERATURES;
-using com::seagate::kinetic::client::proto::Command_GetLog_Type_CAPACITIES;
-using com::seagate::kinetic::client::proto::Command_GetLog_Type_CONFIGURATION;
-using com::seagate::kinetic::client::proto::Command_GetLog_Type_STATISTICS;
-using com::seagate::kinetic::client::proto::Command_GetLog_Type_MESSAGES;
-using com::seagate::kinetic::client::proto::Command_GetLog_Type_LIMITS;
-using com::seagate::kinetic::client::proto::Command_Security_ACL;
-using com::seagate::kinetic::client::proto::Command_Security_ACL_Permission;
-using com::seagate::kinetic::client::proto::Command_Security_ACL_Scope;
-using com::seagate::kinetic::client::proto::Command_Security_ACL_HMACAlgorithm_HmacSHA1;
-using com::seagate::kinetic::client::proto::Command_Status;
-using com::seagate::kinetic::client::proto::Command_P2POperation;
-using com::seagate::kinetic::client::proto::Command_Synchronization;
-using com::seagate::kinetic::client::proto::Command_Synchronization_FLUSH;
-using com::seagate::kinetic::client::proto::Command_Synchronization_WRITEBACK;
-using com::seagate::kinetic::client::proto::Command_Synchronization_WRITETHROUGH;
-using com::seagate::kinetic::client::proto::Command_PinOperation_PinOpType_UNLOCK_PINOP;
-using com::seagate::kinetic::client::proto::Command_PinOperation_PinOpType_LOCK_PINOP;
-using com::seagate::kinetic::client::proto::Command_PinOperation_PinOpType_ERASE_PINOP;
-using com::seagate::kinetic::client::proto::Command_PinOperation_PinOpType_SECURE_ERASE_PINOP;
-using com::seagate::kinetic::client::proto::Message_AuthType_PINAUTH;
-using com::seagate::kinetic::client::proto::Message_AuthType_HMACAUTH;
-
+using namespace com::seagate::kinetic::client::proto;
 using std::shared_ptr;
 using std::string;
 using std::make_shared;
@@ -532,6 +493,17 @@ HandlerKey NonblockingKineticConnection::GenericGet(const shared_ptr<const strin
     unique_ptr<Command> request = NewCommand(message_type);
 
     request->mutable_body()->mutable_keyvalue()->set_key(*key);
+    return service_->Submit(move(msg), move(request), empty_str_, move(handler));
+}
+
+HandlerKey NonblockingKineticConnection::Flush(
+    const shared_ptr<SimpleCallbackInterface> callback) {
+
+    unique_ptr<Message> msg(new Message());
+    msg->set_authtype(Message_AuthType_HMACAUTH);
+    unique_ptr<Command> request = NewCommand(Command_MessageType_FLUSHALLDATA);
+
+    unique_ptr<SimpleHandler> handler(new SimpleHandler(callback));
     return service_->Submit(move(msg), move(request), empty_str_, move(handler));
 }
 

--- a/src/main/threadsafe_blocking_kinetic_connection.cc
+++ b/src/main/threadsafe_blocking_kinetic_connection.cc
@@ -142,6 +142,10 @@ KineticStatus ThreadsafeBlockingKineticConnection::GetLog(const vector<Command_G
     return connection_->GetLog(types, drive_log);
 }
 
+KineticStatus ThreadsafeBlockingKineticConnection::Flush() {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    return connection_->Flush();
+}
 
 KineticStatus ThreadsafeBlockingKineticConnection::UpdateFirmware(const shared_ptr<const string>
         new_firmware) {

--- a/src/main/threadsafe_nonblocking_kinetic_connection.cc
+++ b/src/main/threadsafe_nonblocking_kinetic_connection.cc
@@ -61,7 +61,6 @@ HandlerKey ThreadsafeNonblockingKineticConnection::Get(const string key, const s
     return connection_->Get(key, callback);
 }
 
-
 HandlerKey ThreadsafeNonblockingKineticConnection::GetNext(const string key, const shared_ptr<GetCallbackInterface> callback){
     std::lock_guard<std::recursive_mutex> guard(mutex_);
     return connection_->GetNext(key, callback);
@@ -195,6 +194,11 @@ HandlerKey ThreadsafeNonblockingKineticConnection::GetLog(const vector<Command_G
         const shared_ptr<GetLogCallbackInterface> callback) {
     std::lock_guard<std::recursive_mutex> guard(mutex_);
     return connection_->GetLog(types, callback);
+}
+
+HandlerKey ThreadsafeNonblockingKineticConnection::Flush(const shared_ptr<SimpleCallbackInterface> callback) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    return connection_->Flush(callback);
 }
 
 HandlerKey ThreadsafeNonblockingKineticConnection::UpdateFirmware(


### PR DESCRIPTION
Previously flush functionality only accessible through setting kinetic::PersistMode to Flush on put / delete commands. 