### PR TITLE
Rewrote CMake build script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ os:
   - osx
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y protobuf-compiler libprotobuf-dev; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update ; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install protobuf; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew link openssl --force; fi
 install:
-  - cmake .
+  - cmake -DBUILD_TEST=on .
   - make -j 8
 before_script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,21 @@ compiler:
 os: 
   - linux
   - osx
-install: 
+before_install:
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y protobuf-compiler libprotobuf-dev; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install protobuf; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew link openssl --force; fi
+install:
   - cmake .
-  - make
+  - make -j 8
 before_script:
-  - git clone https://github.com/Kinetic/kinetic-java
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
   - echo $JAVA_HOME
-  - mvn -f ./kinetic-java/pom.xml -DskipTests clean package 
+  - git clone https://github.com/Kinetic/kinetic-java
+  - mvn -f ./kinetic-java/pom.xml -DskipTests clean package
   - ./kinetic-java/bin/startSimulator.sh &
   - sleep 10
 script: 
-  - ./kinetic_client_test
-  - ./kinetic_integration_test
+  - make check
+  - make integration_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install -y protobuf-compiler libprotobuf-dev; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update ; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install protobuf; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install openssl; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew link openssl --force; fi
 install:
-  - cmake -DBUILD_TEST=on .
-  - make -j 8
+  - cmake -DBUILD_TEST=ON .
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then cmake -DOPENSSL_STATIC=ON .; fi
+  - make
 before_script:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
   - echo $JAVA_HOME

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,18 @@
 cmake_minimum_required(VERSION 2.8.6)
 project(kinetic_cpp_client CXX C)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include(ExternalProject)
 
+################################################################################
+# Compiler flags.
+set(CMAKE_CXX_FLAGS "--std=c++0x -Wall -Wextra -Werror -Wno-unknown-warning-option -Wno-unused-parameter -Wno-null-dereference -Wno-unused-local-typedefs -fPIC")
+if (APPLE)
+    # Ignore deprecated warnings due to OpenSSL
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
+endif ()
+
+################################################################################
+# Library Versioning. Patch version equals commit number.
 execute_process(
         COMMAND git log --oneline
         COMMAND wc -l
@@ -15,59 +26,143 @@ set(PROJECT_VERSION_PATCH ${GIT_COMMITS})
 set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 message(STATUS "Project version set to ${PROJECT_VERSION}")
 
-find_package(OpenSSL REQUIRED)
-find_package(Protobuf REQUIRED)
-find_library(LIBUNWIND "unwind")
-
-option(BUILD_TEST "Build test executables." on)
-option(GOOGLE_STATIC "Build & link google libraries statically. If not set, glog and gflags have to be installed." on)
+################################################################################
+# Configuration.
+option(BUILD_TEST "Build test executables." off)
 option(PTHREAD_LOCKS "Register pthread locks with OpenSSL for thread-safety." on)
-message(STATUS "Set Options: BUILD_TEST=${BUILD_TEST} GOOGLE_STATIC=${GOOGLE_STATIC} PTHREAD_LOCKS=${PTHREAD_LOCKS}")
-
-set(CMAKE_CXX_FLAGS "--std=c++0x -Wall -Wextra -Werror -Wno-unknown-warning-option -Wno-unused-parameter -Wno-null-dereference -Wno-unused-local-typedefs -DGTEST_USE_OWN_TR1_TUPLE=1")
-if(APPLE)
-    # Ignore deprecated warnings due to OpenSSL
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
-endif()
-
-if (GOOGLE_STATIC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-
-    ExternalProject_add(
-            gflags
-            PREFIX ${kinetic_cpp_client_BINARY_DIR}/vendor
-            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gflags-2.0-no-svn-files.tar.gz"
-            URL_MD5 "9084829124e02a7e6be0f0f824523423"
-            CONFIGURE_COMMAND ../gflags/configure --prefix=${kinetic_cpp_client_BINARY_DIR}/vendor --enable-static --with-pic
-    )
-    set(GFLAGS_LIBRARIES ${CMAKE_BINARY_DIR}/vendor/lib/libgflags.a)
-    set(GFLAGS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/vendor/include)
-    ExternalProject_add(
-            glog
-            PREFIX ${kinetic_cpp_client_BINARY_DIR}/vendor
-            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/glog-0.3.3.tar.gz"
-            URL_MD5 "a6fd2c22f8996846e34c763422717c18"
-            PATCH_COMMAND sh ${kinetic_cpp_client_SOURCE_DIR}/patches/apply-glog-patches.sh ${kinetic_cpp_client_SOURCE_DIR}
-            CONFIGURE_COMMAND ../glog/configure --prefix=${kinetic_cpp_client_BINARY_DIR}/vendor --with-gflags=${kinetic_cpp_client_BINARY_DIR}/vendor --enable-static --with-pic
-            DEPENDS gflags
-    )
-    set(GLOG_LIBRARIES ${CMAKE_BINARY_DIR}/vendor/lib/libglog.a)
-    set(GLOG_INCLUDE_DIR ${CMAKE_BINARY_DIR}/vendor/include)
-else ()
-    find_library(GLOG_LIBRARIES glog)
-    find_library(GFLAGS_LIBRARIES gflags)
-    find_path(GFLAGS_INCLUDE_DIR google/gflags.h)
-    find_path(GLOG_INCLUDE_DIR glog/logging.h)
-endif ()
+message(STATUS "Build Options:
+    BUILD_TEST=${BUILD_TEST} PTHREAD_LOCKS=${PTHREAD_LOCKS}")
 
 if (PTHREAD_LOCKS)
     add_definitions("-DUSE_PTHREAD_LOCKS")
 endif ()
 
-add_definitions(-DGOOGLE_STRIP_LOG=2)
+################################################################################
+# Dependencies can either be pre-installed (recommended, especially for OpenSSL) or can be build automatically at
+# compile time and statically linked into the kinetic c++ library. Standard behavior is to link everything that can be
+# found dynamically. You may manually set LIB_STATIC to force static linkage of a library.
+option(GLOG_STATIC OFF)
+option(GFLAGS_STATIC OFF)
+option(PROTOBUF_STATIC OFF)
+option(OPENSSL_STATIC OFF)
 
+find_package(OpenSSL)
+find_package(Protobuf)
+find_package(Gflags)
+find_package(Glog)
+
+if (NOT GLOG_FOUND)
+    set(GLOG_STATIC ON)
+endif()
+if (NOT GFLAGS_FOUND)
+    set(GFLAGS_STATIC ON)
+endif()
+if (NOT PROTOBUF_FOUND)
+    set(PROTOBUF_STATIC ON)
+endif()
+if (NOT OPENSSL_FOUND)
+    set(OPENSSL_STATIC ON)
+endif()
+
+message(STATUS "Dependency Configuration:
+    GLOG_STATIC=${GLOG_STATIC} GFLAGS_STATIC=${GFLAGS_STATIC} PROTOBUF_STATIC=${PROTOBUF_STATIC} OPENSSL_STATIC=${OPENSSL_STATIC}")
+
+set(STATIC_PREFIX ${kinetic_cpp_client_BINARY_DIR}/vendor)
+set(STATIC_LIBDIR ${STATIC_PREFIX}/lib)
+
+if (GFLAGS_STATIC)
+    ExternalProject_add(
+            gflags
+            PREFIX ${STATIC_PREFIX}
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gflags-2.0-no-svn-files.tar.gz"
+            URL_MD5 "9084829124e02a7e6be0f0f824523423"
+            CONFIGURE_COMMAND ../gflags/configure --prefix=${STATIC_PREFIX} --libdir=${STATIC_LIBDIR} --enable-static --with-pic
+    )
+    set(GFLAGS_LIBRARIES ${STATIC_LIBDIR}/libgflags.a)
+    set(GFLAGS_INCLUDE_DIR ${STATIC_PREFIX}/include)
+endif()
+
+if (GLOG_STATIC)
+    if(GFLAGS_STATIC)
+        ExternalProject_add(
+                glog
+                PREFIX ${STATIC_PREFIX}
+                URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/glog-0.3.3.tar.gz"
+                URL_MD5 "a6fd2c22f8996846e34c763422717c18"
+                PATCH_COMMAND sh ${kinetic_cpp_client_SOURCE_DIR}/patches/apply-glog-patches.sh ${kinetic_cpp_client_SOURCE_DIR}
+                CONFIGURE_COMMAND ../glog/configure --prefix=${STATIC_PREFIX} --with-gflags=${STATIC_PREFIX} --libdir=${STATIC_LIBDIR} --enable-static --with-pic
+                DEPENDS gflags
+        )
+    else()
+        ExternalProject_add(
+                glog
+                PREFIX ${STATIC_PREFIX}
+                URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/glog-0.3.3.tar.gz"
+                URL_MD5 "a6fd2c22f8996846e34c763422717c18"
+                PATCH_COMMAND sh ${kinetic_cpp_client_SOURCE_DIR}/patches/apply-glog-patches.sh ${kinetic_cpp_client_SOURCE_DIR}
+                CONFIGURE_COMMAND ../glog/configure --prefix=${STATIC_PREFIX} --libdir=${STATIC_LIBDIR} --enable-static --with-pic
+        )
+    endif()
+    add_definitions(-DGOOGLE_STRIP_LOG=2)
+    set(GLOG_LIBRARIES ${STATIC_LIBDIR}/libglog.a)
+    set(GLOG_INCLUDE_DIR ${STATIC_PREFIX}/include)
+endif ()
+
+if (OPENSSL_STATIC)
+    if(APPLE)
+        # On OSX we must explicitly specify that we want to build for x86-64
+        set(OPENSSL_CONFIGURE_COMMAND ./Configure darwin64-x86_64-cc)
+    else()
+        set(OPENSSL_CONFIGURE_COMMAND ../openssl/config -DPURIFY)
+    endif()
+    ExternalProject_add(
+            openssl
+            PREFIX ${STATIC_PREFIX}
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/openssl-1.0.1g.tar.gz"
+            URL_MD5 "de62b43dfcd858e66a74bee1c834e959"
+            BUILD_IN_SOURCE 1
+            CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND} --prefix=${STATIC_PREFIX} -fPIC
+            BUILD_COMMAND touch apps/openssl && touch openssl.pc && make build_libs libssl.pc libcrypto.pc
+            INSTALL_COMMAND make install_sw
+    )
+    set(OPENSSL_LIBRARIES  ${STATIC_LIBDIR}/libssl.a ${STATIC_LIBDIR}/libcrypto.a)
+    set(OPENSSL_INCLUDE_DIR ${STATIC_PREFIX}/include)
+endif ()
+
+if (PROTOBUF_STATIC)
+    # The protobuf build requires the existence of a protoc binary.
+    ExternalProject_add(
+            protoc
+            PREFIX ${STATIC_PREFIX}/host
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/protobuf-2.5.0.tar.bz2"
+            URL_MD5 "a72001a9067a4c2c4e0e836d0f92ece4"
+            CONFIGURE_COMMAND ../protoc/configure --prefix=${STATIC_PREFIX}/host --enable-static
+    )
+    ExternalProject_add(
+            protobuf
+            PREFIX ${STATIC_PREFIX}
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/protobuf-2.5.0.tar.bz2"
+            URL_MD5 "a72001a9067a4c2c4e0e836d0f92ece4"
+            CONFIGURE_COMMAND ../protobuf/configure --with-protoc=${PROTOC_PATH} --prefix=${STATIC_PREFIX} --libdir=${STATIC_LIBDIR} --enable-static --with-pic
+            DEPENDS protoc
+    )
+    set(PROTOBUF_LIBRARIES ${STATIC_LIBDIR}/libprotobuf.a)
+    set(PROTOBUF_INCLUDE_DIR ${STATIC_PREFIX}/include)
+    set(PROTOC_PATH "${STATIC_PREFIX}/host/bin/protoc")
+else()
+    set(PROTOC_PATH "protoc")
+endif ()
+
+# If libunwind is installed it is used by glog and thus has to linked.
+# Otherwise glog uses the standard glibc unwinder and there is no dependency.
+find_library(LIBUNWIND "unwind")
+if (LIBUNWIND)
+    set(GLOG_LIBRARIES ${GLOG_LIBRARIES} ${LIBUNWIND})
+endif ()
+
+################################################################################
+# Download and compile google protobuf kinetic protocol definition
 set(GENERATED_SOURCES_PATH ${kinetic_cpp_client_SOURCE_DIR}/src/main/generated)
-
 ExternalProject_add(kinetic-proto
         PREFIX proto
         GIT_REPOSITORY https://github.com/Seagate/kinetic-protocol
@@ -78,30 +173,23 @@ ExternalProject_add(kinetic-proto
         BUILD_COMMAND sed s/com\\.seagate\\.kinetic\\.proto/com.seagate.kinetic.client.proto/ kinetic.proto > kinetic_client.proto
         INSTALL_COMMAND cp kinetic_client.proto ${GENERATED_SOURCES_PATH}/kinetic_client.proto
         )
-
 add_custom_command(
         COMMENT "Compiling protobuf"
         OUTPUT ${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc ${GENERATED_SOURCES_PATH}/kinetic_client.pb.h
-        COMMAND protoc --proto_path=${GENERATED_SOURCES_PATH} --cpp_out=${GENERATED_SOURCES_PATH} ${GENERATED_SOURCES_PATH}/kinetic_client.proto
+        COMMAND ${PROTOC_PATH} --proto_path=${GENERATED_SOURCES_PATH} --cpp_out=${GENERATED_SOURCES_PATH} ${GENERATED_SOURCES_PATH}/kinetic_client.proto
         COMMAND cp ${GENERATED_SOURCES_PATH}/kinetic_client.pb.h ${kinetic_cpp_client_SOURCE_DIR}/include/kinetic
         DEPENDS kinetic-proto
 )
 add_custom_target(proto-compile
         DEPENDS ${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc ${GENERATED_SOURCES_PATH}/kinetic_client.pb.h
         )
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${GENERATED_SOURCES_PATH})
+if (PROTOBUF_STATIC)
+    add_dependencies(proto-compile protobuf)
+endif()
 set_source_files_properties(${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc PROPERTIES GENERATED TRUE)
 
-# If libunwind is installed it is used by glog and thus has to linked.
-# Otherwise glog uses the standard glibc unwinder and there is no dependency.
-find_library(LIBUNWIND "unwind")
-if (LIBUNWIND)
-    set(GLOG_LIBRARIES
-            ${GLOG_LIBRARIES}
-            ${LIBUNWIND}
-            )
-endif (LIBUNWIND)
-
+################################################################################
+# Main library compilation
 include_directories(
         include
         src/main
@@ -141,10 +229,18 @@ add_library(kinetic_client SHARED ${KINETIC_SRC})
 
 add_dependencies(kinetic_client_static proto-compile)
 add_dependencies(kinetic_client proto-compile)
-if (GOOGLE_STATIC)
-    add_dependencies(kinetic_client_static gflags glog)
-    add_dependencies(kinetic_client gflags glog)
+if (GLOG_STATIC)
+    add_dependencies(kinetic_client_static glog)
+    add_dependencies(kinetic_client glog)
 endif ()
+if (GFLAGS_STATIC)
+    add_dependencies(kinetic_client_static gflags)
+    add_dependencies(kinetic_client gflags)
+endif()
+if (OPENSSL_STATIC)
+    add_dependencies(kinetic_client_static openssl)
+    add_dependencies(kinetic_client openssl)
+endif()
 
 target_link_libraries(kinetic_client_static
         ${OPENSSL_LIBRARIES}
@@ -161,7 +257,6 @@ target_link_libraries(kinetic_client
 
 set_target_properties(kinetic_client PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
-# Set lib or lib64 depending on architecture
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
 set(LIBSUFFIX "")
 if ("${LIB64}" STREQUAL "TRUE" AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
@@ -175,6 +270,7 @@ install(TARGETS kinetic_client
 install(DIRECTORY ${kinetic_cpp_client_SOURCE_DIR}/include/
         DESTINATION include)
 
+################################################################################
 # Rule for generating docs
 configure_file(${kinetic_cpp_client_SOURCE_DIR}/Doxyfile ${kinetic_cpp_client_BINARY_DIR}/Doxyfile)
 add_custom_target(doc
@@ -184,8 +280,11 @@ add_custom_target(doc
         )
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES docs)
 
+################################################################################
+# Test-suite compilation and custom make targets
 if (BUILD_TEST)
     find_package(Threads REQUIRED)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1")
 
     ExternalProject_add(
             gtest
@@ -233,13 +332,10 @@ if (BUILD_TEST)
 
     target_link_libraries(kinetic_client_test
             kinetic_client
-            ${OPENSSL_LIBRARIES}
-            ${PROTOBUF_LIBRARIES}
-            ${GLOG_LIBRARIES}
-            ${GFLAGS_LIBRARIES}
             ${CMAKE_BINARY_DIR}/vendor/src/gtest/libgtest.a
             ${CMAKE_BINARY_DIR}/vendor/src/gmock/libgmock.a
             ${CMAKE_THREAD_LIBS_INIT}
+            ${CMAKE_DL_LIBS}
             )
 
     add_executable(kinetic_integration_test
@@ -254,13 +350,10 @@ if (BUILD_TEST)
 
     target_link_libraries(kinetic_integration_test
             kinetic_client
-            ${OPENSSL_LIBRARIES}
-            ${PROTOBUF_LIBRARIES}
-            ${GLOG_LIBRARIES}
-            ${GFLAGS_LIBRARIES}
             ${CMAKE_BINARY_DIR}/vendor/src/gtest/libgtest.a
             ${CMAKE_BINARY_DIR}/vendor/src/gmock/libgmock.a
             ${CMAKE_THREAD_LIBS_INIT}
+            ${CMAKE_DL_LIBS}
             )
 
     # Rules for running unit and integration tests
@@ -297,11 +390,17 @@ set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
 set(CPACK_RPM_PACKAGE_LICENSE "Mozilla Public License, v. 2.0")
 set(CPACK_RPM_PACKAGE_DESCRIPTION "A c++ client for the kinetic protocol. See https://www.openkinetic.org/ for information on the Kinetic Open Storage Project. Source code available at https://github.com/Kinetic/kinetic-cpp-client")
 set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
-if (GOOGLE_STATIC)
-    set(CPACK_RPM_PACKAGE_REQUIRES "openssl, protobuf")
-else ()
-    set(CPACK_RPM_PACKAGE_REQUIRES "google-glog, gflags, openssl, protobuf")
+if (NOT GLOG_STATIC)
+    set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES} google-glog")
 endif ()
-
+if (NOT GFLAGS_STATIC)
+    set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES} gflags")
+endif ()
+if (NOT PROTOBUF_STATIC)
+    set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES} protobuf")
+endif ()
+if (NOT OPENSSL_STATIC)
+    set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES} openssl")
+endif ()
 set(CPACK_GENERATOR "RPM")
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,285 +1,307 @@
 cmake_minimum_required(VERSION 2.8.6)
 project(kinetic_cpp_client CXX C)
-
-#
-# Add a coverage mode build type
-#
-set(CMAKE_CXX_FLAGS_COVERAGE "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
-set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_C_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
-set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE string
-    "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel Coverage"
-    FORCE)
-
-find_package (Threads)
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-option(BUILD_FOR_ARM "Build for ARM instead of x86" off)
-option(BUILD_PIC "Build static PIC" off)
-
-set(BUILD_PIC_COMPILER_FLAGS "")
-
-if(BUILD_PIC)
-  set(BUILD_PIC_COMPILER_FLAGS "-fPIC")
-endif(BUILD_PIC)
-
-if(APPLE)
-  # On OSX we must explicitly specify that we want to build for x86-64
-  set(OPENSSL_CONFIGURE_COMMAND ./Configure darwin64-x86_64-cc)
-else(APPLE)
-  if(${BUILD_FOR_ARM})
-    set(CMAKE_C_COMPILER "arm-marvell-linux-gnueabi-gcc")
-    set(CMAKE_CXX_COMPILER "arm-marvell-linux-gnueabi-g++")
-    set(CMAKE_RANLIB "arm-marvell-linux-gnueabi-ranlib")
-    set(OPENSSL_CONFIGURE_COMMAND ../openssl/Configure linux-armv4)
-    set(CONFIG_HOST_FLAG --host=arm)
-    set(CHILD_MAKE_FLAGS CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} RANLIB=${CMAKE_RANLIB})
-  else(${BUILD_FOR_ARM})
-    set(CMAKE_C_COMPILER "gcc")
-    set(CMAKE_CXX_COMPILER "g++")
-    set(OPENSSL_CONFIGURE_COMMAND ../openssl/config -DPURIFY)
-  endif(${BUILD_FOR_ARM})
-endif(APPLE)
-
-set(CMAKE_CXX_FLAGS "--std=c++0x -Wall -Wextra -Werror -Wno-unknown-warning-option -Wno-unused-parameter -Wno-null-dereference -Wno-unused-local-typedefs -DGTEST_USE_OWN_TR1_TUPLE=1 ${BUILD_PIC_COMPILER_FLAGS}")
-
-set(TEST_BINARY "kinetic_client_test")
-set(TEST_BINARY_PATH ${kinetic_cpp_client_BINARY_DIR}/${TEST_BINARY})
-set(INTEGRATION_TEST_BINARY "kinetic_integration_test")
-set(INTEGRATION_TEST_BINARY_PATH ${kinetic_cpp_client_BINARY_DIR}/${INTEGRATION_TEST_BINARY})
-set(TEST_LIBRARIES
-    glog
-    gtest
-    gmock
-    openssl
-)
-
-set(GENERATED_SOURCES_PATH ${kinetic_cpp_client_BINARY_DIR}/src/main/generated)
-
-set(PREFIX "${CMAKE_BINARY_DIR}/vendor")
-set(EXTERNAL_PREFIX "${kinetic_cpp_client_BINARY_DIR}/vendor")
-
 include(ExternalProject)
 
-set(KINETIC_PROTO_VERSION "3.0.0")
-set(KINETIC_PROTO_MD5 "85ca027b870811a297c1f6d792498934")
-
-ExternalProject_add(
-    kinetic-proto
-    PREFIX ${PREFIX}
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/kinetic-protocol-${KINETIC_PROTO_VERSION}.tar.gz"
-    URL_MD5 ${KINETIC_PROTO_MD5}
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
+execute_process(
+        COMMAND git log --oneline
+        COMMAND wc -l
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMITS
+        OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+set(PROJECT_VERSION_MAJOR 0)
+set(PROJECT_VERSION_MINOR 2)
+set(PROJECT_VERSION_PATCH ${GIT_COMMITS})
+set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
+message(STATUS "Project version set to ${PROJECT_VERSION}")
 
-ExternalProject_add(
-    gflags
-    PREFIX ${EXTERNAL_PREFIX}
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gflags-2.0-no-svn-files.tar.gz"
-    URL_MD5 "9084829124e02a7e6be0f0f824523423"
-    CONFIGURE_COMMAND ../gflags/configure --prefix=${EXTERNAL_PREFIX} --enable-static ${CONFIG_HOST_FLAG} ${CHILD_MAKE_FLAGS} ${PIC_MAKE_FLAGS}
-)
-
-ExternalProject_add(
-    glog
-    PREFIX ${EXTERNAL_PREFIX}
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/glog-0.3.3.tar.gz"
-    URL_MD5 "a6fd2c22f8996846e34c763422717c18"
-    PATCH_COMMAND sh ${kinetic_cpp_client_SOURCE_DIR}/patches/apply-glog-patches.sh ${kinetic_cpp_client_SOURCE_DIR}
-    CONFIGURE_COMMAND ../glog/configure --prefix=${EXTERNAL_PREFIX} --with-gflags=${EXTERNAL_PREFIX} --enable-static ${CONFIG_HOST_FLAG} ${CHILD_MAKE_FLAGS} ${PIC_MAKE_FLAGS}
-    DEPENDS gflags
-)
-
-ExternalProject_add(
-    gtest
-    PREFIX ${EXTERNAL_PREFIX}
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gtest-1.6.0.zip"
-    URL_MD5 "4577b49f2973c90bf9ba69aa8166b786"
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${CMAKE_CXX_COMPILER} -DGTEST_USE_OWN_TR1_TUPLE=1 -I../gtest -I../gtest/include -c ../gtest/src/gtest-all.cc && ar -rv libgtest.a gtest-all.o && ranlib libgtest.a
-    INSTALL_COMMAND ""
-)
-
-ExternalProject_add(
-    gmock
-    PREFIX ${EXTERNAL_PREFIX}
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gmock-1.6.0.zip"
-    URL_MD5 "f547f47321ca88d3965ca2efdcc2a3c1"
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${CMAKE_CXX_COMPILER} -DGTEST_USE_OWN_TR1_TUPLE=1 -I../gmock -I../gmock/include -I../gtest -I../gtest/include -c ../gmock/src/gmock-all.cc && ar -rv libgmock.a gmock-all.o && ranlib libgmock.a
-    INSTALL_COMMAND ""
-    DEPENDS gtest
-)
-
-ExternalProject_add(
-    openssl
-    PREFIX ${EXTERNAL_PREFIX}
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/openssl-1.0.1g.tar.gz"
-    URL_MD5 "de62b43dfcd858e66a74bee1c834e959"
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND} --prefix=${EXTERNAL_PREFIX} ${BUILD_PIC_COMPILER_FLAG}
-    BUILD_COMMAND touch apps/openssl && touch openssl.pc && make ${CHILD_MAKE_FLAGS} build_libs libssl.pc libcrypto.pc
-    INSTALL_COMMAND make install_sw
-)
-
-# The protobuf build requires the existence of a protoc binary that can be
-# executed on the host machine. To handle cross compilation, we always build
-# protobuf once for the host so that we have a suitable copy of protoc.
-ExternalProject_add(
-    protoc
-    PREFIX ${EXTERNAL_PREFIX}/host
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/protobuf-2.5.0.tar.bz2"
-    URL_MD5 "a72001a9067a4c2c4e0e836d0f92ece4"
-    CONFIGURE_COMMAND ../protoc/configure --prefix=${EXTERNAL_PREFIX}/host --enable-static
-)
-
-# Protobuf code generation rules
-set(PROTOC_PATH "${PREFIX}/host/bin/protoc")
-set(PROTO_DIR "${CMAKE_BINARY_DIR}/vendor/src/kinetic-proto")
-set(PROTO_ORIG_PATH "${PROTO_DIR}/kinetic.proto")
-set(PROTO_MODIFIED_PATH "${PROTO_DIR}/kinetic_client.proto")
-ExternalProject_add(
-    protobuf
-    PREFIX ${EXTERNAL_PREFIX}
-    URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/protobuf-2.5.0.tar.bz2"
-    URL_MD5 "a72001a9067a4c2c4e0e836d0f92ece4"
-    CONFIGURE_COMMAND ../protobuf/configure --prefix=${EXTERNAL_PREFIX} --enable-static --with-protoc=${PROTOC_PATH} ${CONFIG_HOST_FLAG} ${CHILD_MAKE_FLAGS} ${PIC_MAKE_FLAGS}
-    DEPENDS protoc
-)
-
-add_custom_command(
-    COMMENT "Compiling protobuf"
-    OUTPUT ${GENERATED_SOURCES_PATH}/kinetic_client.pb.h ${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc
-    COMMAND mkdir -p ${GENERATED_SOURCES_PATH} && sed 's/com\\.seagate\\.kinetic\\.proto/com.seagate.kinetic.client.proto/' ${PROTO_ORIG_PATH} > ${PROTO_MODIFIED_PATH} && ${PROTOC_PATH} -I=${PROTO_DIR} --cpp_out=${GENERATED_SOURCES_PATH} ${PROTO_MODIFIED_PATH}
-    DEPENDS kinetic-proto protoc protobuf
-)
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${GENERATED_SOURCES_PATH})
-
-include_directories(
-    include
-    src/main
-
-    src/test/mock
-    src/test
-
-    ${GENERATED_SOURCES_PATH}
-    ${EXTERNAL_PREFIX}/include
-    ${EXTERNAL_PREFIX}/src/gmock/include
-    ${EXTERNAL_PREFIX}/src/gtest/include
-)
-
-set(LIBRARY_DEPENDENCIES
-    kinetic_client
-    ${CMAKE_BINARY_DIR}/vendor/lib/libglog.a
-    ${CMAKE_BINARY_DIR}/vendor/lib/libgflags.a
-    ${CMAKE_BINARY_DIR}/vendor/lib/libssl.a
-    ${CMAKE_BINARY_DIR}/vendor/lib/libcrypto.a
-    ${CMAKE_BINARY_DIR}/vendor/lib/libprotobuf.a
-    ${CMAKE_BINARY_DIR}/vendor/src/gtest/libgtest.a
-    ${CMAKE_BINARY_DIR}/vendor/src/gmock/libgmock.a
-    ${CMAKE_THREAD_LIBS_INIT}
-    dl
-)
-
-# If libunwind is installed it is used by glog and thus has to linked. 
-# Otherwise glog uses the standard glibc unwinder and there is no dependency.
+find_package(OpenSSL REQUIRED)
+find_package(Protobuf REQUIRED)
 find_library(LIBUNWIND "unwind")
-if(LIBUNWIND)
-    set(LIBRARY_DEPENDENCIES 
-        ${LIBRARY_DEPENDENCIES} 
-        ${LIBUNWIND}
-    )
+
+option(BUILD_TEST "Build test executables." on)
+option(GOOGLE_STATIC "Build & link google libraries statically. If not set, glog and gflags have to be installed." on)
+option(PTHREAD_LOCKS "Register pthread locks with OpenSSL for thread-safety." on)
+message(STATUS "Set Options: BUILD_TEST=${BUILD_TEST} GOOGLE_STATIC=${GOOGLE_STATIC} PTHREAD_LOCKS=${PTHREAD_LOCKS}")
+
+set(CMAKE_CXX_FLAGS "--std=c++0x -Wall -Wextra -Werror -Wno-unknown-warning-option -Wno-unused-parameter -Wno-null-dereference -Wno-unused-local-typedefs -DGTEST_USE_OWN_TR1_TUPLE=1")
+if(APPLE)
+    # Ignore deprecated warnings due to OpenSSL
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
 endif()
 
-add_library(kinetic_client
-    ${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc
-    src/main/hmac_provider.cc
-    src/main/kinetic_connection_factory.cc
-    src/main/nonblocking_kinetic_connection.cc
-    src/main/threadsafe_nonblocking_kinetic_connection.cc
-    src/main/nonblocking_packet.cc
-    src/main/nonblocking_packet_writer_factory.cc
-    src/main/nonblocking_packet_service.cc
-    src/main/nonblocking_packet_sender.cc
-    src/main/nonblocking_packet_receiver.cc
-    src/main/nonblocking_string.cc
-    src/main/socket_wrapper.cc
-    src/main/blocking_kinetic_connection.cc
-    src/main/threadsafe_blocking_kinetic_connection.cc
-    src/main/status_code.cc
-    src/main/byte_stream.cc
-    src/main/incoming_string_value.cc
-    src/main/message_stream.cc
-    src/main/outgoing_string_value.cc
-    src/main/reader_writer.cc
-    src/main/key_range_iterator.cc
-)
-add_dependencies(kinetic_client openssl)
+if (GOOGLE_STATIC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
-add_executable(${TEST_BINARY}
-    src/test/kinetic_cpp_client_test.cc
-    src/test/nonblocking_kinetic_connection_test.cc
-    src/test/nonblocking_packet_service_test.cc
-    src/test/nonblocking_packet_sender_test.cc
-    src/test/nonblocking_packet_receiver_test.cc
-    src/test/nonblocking_packet_test.cc
-    src/test/nonblocking_string_test.cc
-    src/test/hmac_provider_test.cc
-    src/test/message_stream_test.cc
-    src/test/string_value_test.cc
-)
-target_link_libraries(${TEST_BINARY} ${LIBRARY_DEPENDENCIES})
+    ExternalProject_add(
+            gflags
+            PREFIX ${kinetic_cpp_client_BINARY_DIR}/vendor
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gflags-2.0-no-svn-files.tar.gz"
+            URL_MD5 "9084829124e02a7e6be0f0f824523423"
+            CONFIGURE_COMMAND ../gflags/configure --prefix=${kinetic_cpp_client_BINARY_DIR}/vendor --enable-static --with-pic
+    )
+    set(GFLAGS_LIBRARIES ${CMAKE_BINARY_DIR}/vendor/lib/libgflags.a)
+    set(GFLAGS_INCLUDE_DIR ${CMAKE_BINARY_DIR}/vendor/include)
+    ExternalProject_add(
+            glog
+            PREFIX ${kinetic_cpp_client_BINARY_DIR}/vendor
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/glog-0.3.3.tar.gz"
+            URL_MD5 "a6fd2c22f8996846e34c763422717c18"
+            PATCH_COMMAND sh ${kinetic_cpp_client_SOURCE_DIR}/patches/apply-glog-patches.sh ${kinetic_cpp_client_SOURCE_DIR}
+            CONFIGURE_COMMAND ../glog/configure --prefix=${kinetic_cpp_client_BINARY_DIR}/vendor --with-gflags=${kinetic_cpp_client_BINARY_DIR}/vendor --enable-static --with-pic
+            DEPENDS gflags
+    )
+    set(GLOG_LIBRARIES ${CMAKE_BINARY_DIR}/vendor/lib/libglog.a)
+    set(GLOG_INCLUDE_DIR ${CMAKE_BINARY_DIR}/vendor/include)
+else ()
+    find_library(GLOG_LIBRARIES glog)
+    find_library(GFLAGS_LIBRARIES gflags)
+    find_path(GFLAGS_INCLUDE_DIR google/gflags.h)
+    find_path(GLOG_INCLUDE_DIR glog/logging.h)
+endif ()
 
-add_executable(${INTEGRATION_TEST_BINARY}
-    src/integration_test/delete_test.cc
-    src/integration_test/get_test.cc
-    src/integration_test/nonexistent_server_test.cc
-    src/integration_test/put_test.cc
-    src/integration_test/blocking_smoketest.cc
-    src/test/kinetic_cpp_client_test.cc
-)
-target_link_libraries(${INTEGRATION_TEST_BINARY} ${LIBRARY_DEPENDENCIES})
+if (PTHREAD_LOCKS)
+    add_definitions("-DUSE_PTHREAD_LOCKS")
+endif ()
 
-# Rule for running unit tests
-add_custom_target(check
-    COMMAND ${TEST_BINARY_PATH} --gtest_output=xml:gtestresults.xml
-    DEPENDS ${TEST_BINARY_PATH}
+add_definitions(-DGOOGLE_STRIP_LOG=2)
+
+set(GENERATED_SOURCES_PATH ${kinetic_cpp_client_SOURCE_DIR}/src/main/generated)
+
+ExternalProject_add(kinetic-proto
+        PREFIX proto
+        GIT_REPOSITORY https://github.com/Seagate/kinetic-protocol
+        GIT_TAG 3.0.0
+        UPDATE_COMMAND mkdir -p ${GENERATED_SOURCES_PATH}
+        CONFIGURE_COMMAND ""
+        BUILD_IN_SOURCE 1
+        BUILD_COMMAND sed s/com\\.seagate\\.kinetic\\.proto/com.seagate.kinetic.client.proto/ kinetic.proto > kinetic_client.proto
+        INSTALL_COMMAND cp kinetic_client.proto ${GENERATED_SOURCES_PATH}/kinetic_client.proto
+        )
+
+add_custom_command(
+        COMMENT "Compiling protobuf"
+        OUTPUT ${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc ${GENERATED_SOURCES_PATH}/kinetic_client.pb.h
+        COMMAND protoc --proto_path=${GENERATED_SOURCES_PATH} --cpp_out=${GENERATED_SOURCES_PATH} ${GENERATED_SOURCES_PATH}/kinetic_client.proto
+        COMMAND cp ${GENERATED_SOURCES_PATH}/kinetic_client.pb.h ${kinetic_cpp_client_SOURCE_DIR}/include/kinetic
+        DEPENDS kinetic-proto
+)
+add_custom_target(proto-compile
+        DEPENDS ${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc ${GENERATED_SOURCES_PATH}/kinetic_client.pb.h
+        )
+set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${GENERATED_SOURCES_PATH})
+set_source_files_properties(${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc PROPERTIES GENERATED TRUE)
+
+# If libunwind is installed it is used by glog and thus has to linked.
+# Otherwise glog uses the standard glibc unwinder and there is no dependency.
+find_library(LIBUNWIND "unwind")
+if (LIBUNWIND)
+    set(GLOG_LIBRARIES
+            ${GLOG_LIBRARIES}
+            ${LIBUNWIND}
+            )
+endif (LIBUNWIND)
+
+include_directories(
+        include
+        src/main
+        ${GENERATED_SOURCES_PATH}
+        ${PROTOBUF_INCLUDE_DIR}
+        ${OPENSSL_INCLUDE_DIR}
+        ${GFLAGS_INCLUDE_DIR}
+        ${GLOG_INCLUDE_DIR}
 )
 
-# Rule for running integration tests
-add_custom_target(integration_test
-    COMMAND ${INTEGRATION_TEST_BINARY_PATH} --gtest_output=xml:integrationresults.xml
-    DEPENDS ${INTEGRATION_TEST_BINARY_PATH}
-)
+set(KINETIC_SRC
+        ${GENERATED_SOURCES_PATH}/kinetic_client.pb.cc
+        src/main/hmac_provider.cc
+        src/main/kinetic_connection_factory.cc
+        src/main/nonblocking_kinetic_connection.cc
+        src/main/threadsafe_nonblocking_kinetic_connection.cc
+        src/main/nonblocking_packet.cc
+        src/main/nonblocking_packet_writer_factory.cc
+        src/main/nonblocking_packet_service.cc
+        src/main/nonblocking_packet_sender.cc
+        src/main/nonblocking_packet_receiver.cc
+        src/main/nonblocking_string.cc
+        src/main/socket_wrapper.cc
+        src/main/blocking_kinetic_connection.cc
+        src/main/threadsafe_blocking_kinetic_connection.cc
+        src/main/status_code.cc
+        src/main/byte_stream.cc
+        src/main/incoming_string_value.cc
+        src/main/message_stream.cc
+        src/main/outgoing_string_value.cc
+        src/main/reader_writer.cc
+        src/main/key_range_iterator.cc
+        )
 
-# Rules for running unit and integration tests under Valgrind
-add_custom_target(test_valgrind
-    COMMAND valgrind --leak-check=full --show-reachable=yes --track-fds=yes --suppressions=${kinetic_cpp_client_SOURCE_DIR}/valgrind_linux.supp ${TEST_BINARY_PATH}
-    DEPENDS ${TEST_BINARY_PATH}
-)
-add_custom_target(integration_test_valgrind
-    COMMAND valgrind --leak-check=full --show-reachable=yes --track-fds=yes --suppressions=${kinetic_cpp_client_SOURCE_DIR}/valgrind_linux.supp ${INTEGRATION_TEST_BINARY_PATH}
-    DEPENDS ${INTEGRATION_TEST_BINARY_PATH}
-)
+add_library(kinetic_client_static STATIC ${KINETIC_SRC})
+add_library(kinetic_client SHARED ${KINETIC_SRC})
+
+add_dependencies(kinetic_client_static proto-compile)
+add_dependencies(kinetic_client proto-compile)
+if (GOOGLE_STATIC)
+    add_dependencies(kinetic_client_static gflags glog)
+    add_dependencies(kinetic_client gflags glog)
+endif ()
+
+target_link_libraries(kinetic_client_static
+        ${OPENSSL_LIBRARIES}
+        ${PROTOBUF_LIBRARIES}
+        ${GLOG_LIBRARIES}
+        ${GFLAGS_LIBRARIES}
+        )
+target_link_libraries(kinetic_client
+        ${OPENSSL_LIBRARIES}
+        ${PROTOBUF_LIBRARIES}
+        ${GLOG_LIBRARIES}
+        ${GFLAGS_LIBRARIES}
+        )
+
+set_target_properties(kinetic_client PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+
+# Set lib or lib64 depending on architecture
+get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
+set(LIBSUFFIX "")
+if ("${LIB64}" STREQUAL "TRUE" AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set(LIBSUFFIX 64)
+endif ()
+message(STATUS "Library installation directory is set to ${CMAKE_INSTALL_PREFIX}/lib${LIBSUFFIX}")
+
+install(TARGETS kinetic_client
+        LIBRARY
+        DESTINATION lib${LIBSUFFIX})
+install(DIRECTORY ${kinetic_cpp_client_SOURCE_DIR}/include/
+        DESTINATION include)
 
 # Rule for generating docs
 configure_file(${kinetic_cpp_client_SOURCE_DIR}/Doxyfile ${kinetic_cpp_client_BINARY_DIR}/Doxyfile)
 add_custom_target(doc
-    doxygen ${kinetic_cpp_client_BINARY_DIR}/Doxyfile
-    WORKING_DIRECTORY ${kinetic_cpp_client_BINARY_DIR}
-    COMMENT "Generating API documentation with Doxygen" VERBATIM
-)
+        doxygen ${kinetic_cpp_client_BINARY_DIR}/Doxyfile
+        WORKING_DIRECTORY ${kinetic_cpp_client_BINARY_DIR}
+        COMMENT "Generating API documentation with Doxygen" VERBATIM
+        )
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES docs)
 
-# Rule for linting
-configure_file(${kinetic_cpp_client_SOURCE_DIR}/bin/lint.sh ${kinetic_cpp_client_BINARY_DIR}/bin/lint.sh @ONLY)
-add_custom_target(lint
-    ${kinetic_cpp_client_BINARY_DIR}/bin/lint.sh
-    WORKING_DIRECTORY ${kinetic_cpp_client_BINARY_DIR}
-    COMMENT "Running style checker" VERBATIM
-)
+if (BUILD_TEST)
+    find_package(Threads REQUIRED)
+
+    ExternalProject_add(
+            gtest
+            PREFIX vendor
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gtest-1.6.0.zip"
+            URL_MD5 "4577b49f2973c90bf9ba69aa8166b786"
+            BUILD_IN_SOURCE 1
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ${CMAKE_CXX_COMPILER} -DGTEST_USE_OWN_TR1_TUPLE=1 -I../gtest -I../gtest/include -c ../gtest/src/gtest-all.cc && ar -rv libgtest.a gtest-all.o && ranlib libgtest.a
+            INSTALL_COMMAND ""
+    )
+
+    ExternalProject_add(
+            gmock
+            PREFIX vendor
+            URL "${kinetic_cpp_client_SOURCE_DIR}/tarballs/gmock-1.6.0.zip"
+            URL_MD5 "f547f47321ca88d3965ca2efdcc2a3c1"
+            BUILD_IN_SOURCE 1
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND ${CMAKE_CXX_COMPILER} -DGTEST_USE_OWN_TR1_TUPLE=1 -I../gmock -I../gmock/include -I../gtest -I../gtest/include -c ../gmock/src/gmock-all.cc && ar -rv libgmock.a gmock-all.o && ranlib libgmock.a
+            INSTALL_COMMAND ""
+            DEPENDS gtest
+    )
+
+    include_directories(
+            src/test/mock
+            src/test
+            ${kinetic_cpp_client_BINARY_DIR}/vendor/src/gmock/include
+            ${kinetic_cpp_client_BINARY_DIR}/vendor/src/gtest/include
+    )
+
+    add_executable(kinetic_client_test
+            src/test/kinetic_cpp_client_test.cc
+            src/test/nonblocking_kinetic_connection_test.cc
+            src/test/nonblocking_packet_service_test.cc
+            src/test/nonblocking_packet_sender_test.cc
+            src/test/nonblocking_packet_receiver_test.cc
+            src/test/nonblocking_packet_test.cc
+            src/test/nonblocking_string_test.cc
+            src/test/hmac_provider_test.cc
+            src/test/message_stream_test.cc
+            src/test/string_value_test.cc
+            )
+    add_dependencies(kinetic_client_test kinetic_client gtest gmock)
+
+    target_link_libraries(kinetic_client_test
+            kinetic_client
+            ${OPENSSL_LIBRARIES}
+            ${PROTOBUF_LIBRARIES}
+            ${GLOG_LIBRARIES}
+            ${GFLAGS_LIBRARIES}
+            ${CMAKE_BINARY_DIR}/vendor/src/gtest/libgtest.a
+            ${CMAKE_BINARY_DIR}/vendor/src/gmock/libgmock.a
+            ${CMAKE_THREAD_LIBS_INIT}
+            )
+
+    add_executable(kinetic_integration_test
+            src/integration_test/delete_test.cc
+            src/integration_test/get_test.cc
+            src/integration_test/nonexistent_server_test.cc
+            src/integration_test/put_test.cc
+            src/integration_test/blocking_smoketest.cc
+            src/test/kinetic_cpp_client_test.cc
+            )
+    add_dependencies(kinetic_integration_test kinetic_client gtest gmock)
+
+    target_link_libraries(kinetic_integration_test
+            kinetic_client
+            ${OPENSSL_LIBRARIES}
+            ${PROTOBUF_LIBRARIES}
+            ${GLOG_LIBRARIES}
+            ${GFLAGS_LIBRARIES}
+            ${CMAKE_BINARY_DIR}/vendor/src/gtest/libgtest.a
+            ${CMAKE_BINARY_DIR}/vendor/src/gmock/libgmock.a
+            ${CMAKE_THREAD_LIBS_INIT}
+            )
+
+    # Rules for running unit and integration tests
+    add_custom_target(check
+            COMMAND ${kinetic_cpp_client_BINARY_DIR}/kinetic_client_test --gtest_output=xml:gtestresults.xml
+            DEPENDS ${kinetic_cpp_client_BINARY_DIR}/kinetic_client_test
+            )
+    add_custom_target(integration_test
+            COMMAND ${kinetic_cpp_client_BINARY_DIR}/kinetic_integration_test --gtest_output=xml:integrationresults.xml
+            DEPENDS ${kinetic_cpp_client_BINARY_DIR}/kinetic_integration_test
+            )
+
+    # Rules for running unit and integration tests under Valgrind
+    add_custom_target(test_valgrind
+            COMMAND valgrind --leak-check=full --show-reachable=yes --track-fds=yes --suppressions=${kinetic_cpp_client_SOURCE_DIR}/valgrind_linux.supp ${kinetic_cpp_client_BINARY_DIR}/kinetic_client_test
+            DEPENDS ${kinetic_cpp_client_BINARY_DIR}/kinetic_client_test
+            )
+    add_custom_target(integration_test_valgrind
+            COMMAND valgrind --leak-check=full --show-reachable=yes --track-fds=yes --suppressions=${kinetic_cpp_client_SOURCE_DIR}/valgrind_linux.supp ${kinetic_cpp_client_BINARY_DIR}/kinetic_integration_test
+            DEPENDS ${kinetic_cpp_client_BINARY_DIR}/kinetic_integration_test
+            )
+endif ()
+
+
+################################################################################
+# RPM generation rules
+set(CPACK_PACKAGE_CONTACT "paul.h.lensing@seagate.com")
+set(CPACK_PACKAGE_NAME ${CMAKE_PROJECT_NAME})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "kinetic c++ client")
+set(CPACK_PACKAGE_VENDOR "Kinetic Open Storage Project")
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
+
+set(CPACK_RPM_PACKAGE_LICENSE "Mozilla Public License, v. 2.0")
+set(CPACK_RPM_PACKAGE_DESCRIPTION "A c++ client for the kinetic protocol. See https://www.openkinetic.org/ for information on the Kinetic Open Storage Project. Source code available at https://github.com/Kinetic/kinetic-cpp-client")
+set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
+if (GOOGLE_STATIC)
+    set(CPACK_RPM_PACKAGE_REQUIRES "openssl, protobuf")
+else ()
+    set(CPACK_RPM_PACKAGE_REQUIRES "google-glog, gflags, openssl, protobuf")
+endif ()
+
+set(CPACK_GENERATOR "RPM")
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build Status](https://travis-ci.org/Kinetic/kinetic-cpp-client.svg?branch=master)](https://travis-ci.org/Kinetic/kinetic-cpp-client)
+
 Introduction
 ============
-This repo contains code for producing C and C++ kinetic clients. The C++ library currently does not support Windows at this time because of existing library requirements.
-
+This repository contains a C++ kinetic client implementation.
 
 Protocol Version
 =================
@@ -11,23 +11,60 @@ The client is using version `3.0.0` of the [Kinetic-Protocol](https://github.com
 
 Dependencies
 ============
-* CMake
-* Valgrind for memory tests
-* Doxygen/graphviz for generating documentation
-* curl
 
-Initial Setup
-=============
+### Running 
+* openssl and protobuf libraries
+* optional (see [build options](#build-options)): glog and gflags libraries 
+
+### Building 
+* cmake 
+* gcc 4.4 or higher. Or other c++ compiler supporting at least the c++0x feature set provided by gcc 4.4.
+* openssl and protobuf headers
+* protobuf-compiler
+* optional (see [build options](#build-options)): glog and gflags headers 
+
+### Other
+* doxygen/graphviz for generating documentation
+* valgrind for running tests with leak detection (3.12+ required to run with openssl)
+
+Compilation
+============
 1. Install any missing dependencies
-1. Run `cmake .` to build a static library, or `cmake . -DBUILD_SHARED_LIBS=true` to build a shared library.
-1. Run `make`
+2. Clone this git repository 
+3. Create a build directory. If you want you can use the cloned git repository as your build directory, but using a separate directory is recommended in order to cleanly separate sources and generated files. 
+4. From your build directory call `cmake /path/to/git`, if you're using the cloned git repository as your build directory this would be `cmake .` 
+5. Run `make`
+
+#### BUILD OPTIONS:
+The following cmake options modify build behavior. All options are enabled by default, they may be disabled using the `cmake -DOPTION=OFF /path/to/git` syntax. 
+
++ GOOGLE_STATIC: Builds static glog and gflags libraries and links them into the generated kinetic-cpp-client library. This makes life a little easier as the google libraries do not have to be installed separately. To prevent linker errors, unset if you are using either library in the application linking the kinetic-cpp-client library.   
++ PTHREAD_LOCKS: If set, pthread locks are registered with the OpenSSL library to ensure thread safety. Unset if you are compiling in a non-pthread environment or otherwise wish to register locks yourself from your application. 
++ BUILD_TEST: Builds unit and integration tests.
+
+Versioning
+============
+The library follows the Major.Minor.Patch versioning scheme, `.so` versioning is done automatically during compilation. 
+
+Changes to the *Major* version indicate that the library interface has changed. Different *Major* versions of the library will not be binary compatible. 
+
+Changes to the *Minor* version number indicate that backwards compatible changes to the interface have ocurred. Usually this means that additional functions are available. It resets to zero if the *Major* version changes. 
+
+The patch version equals the git commit number to allow easily associating an installed library version with a particular git commit. It does not reset if the *Major* or *Minor* versions change.  
+
+
+Installation
+============
+ `sudo make install` 
+
+RPM PACKAGE GENERATION: 
+============
+`make package`
 
 Common Developer Tasks
 ======================
 
-**Building the lib**: `make`. It will be in `libkinetic_client.a`
-
-**Running tests**: To run the unit test suite, run `make check`. Tests results
+**Running tests**: To run the unit test suite, run `make check`. This make target will only be generated if BUILD_TEST cmake option is set. Tests results
 will appear on stdout and a JUnit report be written to `gtestresults.xml`
 
 There is also an integration test suite. This suite reads the environment
@@ -40,8 +77,4 @@ a JUnit report to `integrationresults.xml`.
 **Running tests with leak check**: Run `make test_valgrind` for the unit test
 suite or `make integration_test_valgrind` for the integration test suite.
 
-**Checking code style**: `make lint`. Violations will be printed on stdout.
-
 **Generating documentation**: `make doc`. HTML documentation will be generated in `docs/`
-
-**Apply licenses**: Run something like `./apply_license.sh my_new_file.cc` or `./apply_license.sh src/*.h`

--- a/README.md
+++ b/README.md
@@ -11,17 +11,21 @@ The client is using version `3.0.0` of the [Kinetic-Protocol](https://github.com
 
 Dependencies
 ============
-
-### Running 
-* openssl and protobuf libraries
-* optional (see [build options](#build-options)): glog and gflags libraries 
-
-### Building 
 * cmake 
-* gcc 4.4 or higher. Or other c++ compiler supporting at least the c++0x feature set provided by gcc 4.4.
-* openssl and protobuf headers
-* protobuf-compiler
-* optional (see [build options](#build-options)): glog and gflags headers 
+* gcc 4.4 or higher. Or another c++ compiler supporting at least the c++0x feature set provided by gcc 4.4.
+
+### Optional Dependencies 
+
+* glog, gflags, openssl, protobuf, protobuf-compiler
+
+If a library is not found installed on the system, it will be build and linked statically into the kinetic-cpp-client library. Static linkage may be convenient, but will drastically increase build time for the kinetic-cpp-client and may land you in linker-hell should you attempt to use the same libraries in your application.
+
+It is **strongly recommended** to at least install the openssl and protobuf libraries. On most platforms, package managers will install the corresponding packages with their development files for you. E.g. 
+ * yum install openssl openssl-devel protobuf-devel 
+ * apt-get install openssl libssl-dev libprotobuf-dev protobuf-compiler  
+ * brew install openssl protobuf
+
+You may force static linkage by setting the corresponding `LIBNAME_STATIC` variable. This may be desirable if you plan deploying the compiled library on other machines. As an example, `cmake -DPROTOBUF_STATIC=ON /path/to/git` will link protobuf statically into the kinetic-cpp-client even if it is installed on the system that is compiling the library. 
 
 ### Other
 * doxygen/graphviz for generating documentation
@@ -36,11 +40,10 @@ Compilation
 5. Run `make`
 
 #### BUILD OPTIONS:
-The following cmake options modify build behavior. All options are enabled by default, they may be disabled using the `cmake -DOPTION=OFF /path/to/git` syntax. 
+The following cmake options modify build behavior. You may change an option using the `cmake -DOPTION=ON/OFF /path/to/git` syntax. 
 
-+ GOOGLE_STATIC: Builds static glog and gflags libraries and links them into the generated kinetic-cpp-client library. This makes life a little easier as the google libraries do not have to be installed separately. To prevent linker errors, unset if you are using either library in the application linking the kinetic-cpp-client library.   
-+ PTHREAD_LOCKS: If set, pthread locks are registered with the OpenSSL library to ensure thread safety. Unset if you are compiling in a non-pthread environment or otherwise wish to register locks yourself from your application. 
-+ BUILD_TEST: Builds unit and integration tests.
++ PTHREAD_LOCKS (default: on): If set, pthread locks are registered with the OpenSSL library to ensure thread safety. Unset if you are compiling in a non-pthread environment or otherwise wish to register locks yourself from your application. 
++ BUILD_TEST (default: off): Builds unit and integration tests.
 
 Versioning
 ============
@@ -64,7 +67,9 @@ RPM PACKAGE GENERATION:
 Common Developer Tasks
 ======================
 
-**Running tests**: To run the unit test suite, run `make check`. This make target will only be generated if BUILD_TEST cmake option is set. Tests results
+**Running tests**: Ensure you built the test binaries (BUILD_TEST cmake option has to be set).
+
+To run the unit test suite, run `make check`. Tests results
 will appear on stdout and a JUnit report be written to `gtestresults.xml`
 
 There is also an integration test suite. This suite reads the environment

--- a/cmake/FindGflags.cmake
+++ b/cmake/FindGflags.cmake
@@ -1,0 +1,31 @@
+# Try to find gflags library
+# Once done, this will define
+#
+# GFLAGS_FOUND        - system has gflags library
+# GFLAGS_INCLUDE_DIRS - the gflags include directories
+# GFLAGS_LIBRARIES    - gflags libraries
+
+if(GFLAGS_INCLUDE_DIRS AND GFLAGS_LIBRARIES)
+    set(GFLAGS_FIND_QUIETLY TRUE)
+endif(GFLAGS_INCLUDE_DIRS AND GFLAGS_LIBRARIES)
+
+find_path(GFLAGS_INCLUDE_DIR gflags/gflags.h
+        HINTS
+        /usr/include/
+        /usr/local/include/
+        )
+
+find_library(GFLAGS_LIBRARY gflags
+        PATHS /usr/ /usr/local/
+        PATH_SUFFIXES lib lib64
+        )
+
+set(GFLAGS_INCLUDE_DIRS ${GFLAGS_INCLUDE_DIR})
+set(GFLAGS_LIBRARIES ${GFLAGS_LIBRARY})
+
+# handle the QUIETLY and REQUIRED arguments and set GFLAGS_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GFLAGS DEFAULT_MSG GFLAGS_INCLUDE_DIRS GFLAGS_LIBRARIES)
+
+mark_as_advanced(GFLAGS_INCLUDE_DIRS GFLAGS_LIBRARIES)

--- a/cmake/FindGlog.cmake
+++ b/cmake/FindGlog.cmake
@@ -1,0 +1,31 @@
+# Try to find glog library
+# Once done, this will define
+#
+# GLOG_FOUND        - system has glog library
+# GLOG_INCLUDE_DIRS - the glog include directories
+# GLOG_LIBRARIES    - glog libraries
+
+if(GLOG_INCLUDE_DIRS AND GLOG_LIBRARIES)
+    set(GLOG_FIND_QUIETLY TRUE)
+endif(GLOG_INCLUDE_DIRS AND GLOG_LIBRARIES)
+
+find_path(GLOG_INCLUDE_DIR glog/logging.h
+        HINTS
+        /usr/include/
+        /usr/local/include/
+        )
+
+find_library(GLOG_LIBRARY glog
+        PATHS /usr/ /usr/local/
+        PATH_SUFFIXES lib lib64
+        )
+
+set(GLOG_INCLUDE_DIRS ${GLOG_INCLUDE_DIR})
+set(GLOG_LIBRARIES ${GLOG_LIBRARY})
+
+# handle the QUIETLY and REQUIRED arguments and set GLOG_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLOG DEFAULT_MSG GLOG_INCLUDE_DIRS GLOG_LIBRARIES)
+
+mark_as_advanced(GLOG_INCLUDE_DIRS GLOG_LIBRARIES)

--- a/src/main/nonblocking_packet_sender.h
+++ b/src/main/nonblocking_packet_sender.h
@@ -25,8 +25,6 @@
 #include <unordered_map>
 #include <glog/logging.h>
 
-#include "gmock/gmock.h"
-
 #include "kinetic/nonblocking_packet_service_interface.h"
 #include "kinetic/connection_options.h"
 #include "kinetic/hmac_provider.h"

--- a/src/main/nonblocking_packet_service.h
+++ b/src/main/nonblocking_packet_service.h
@@ -25,8 +25,6 @@
 #include <unordered_map>
 #include <glog/logging.h>
 
-#include "gmock/gmock.h"
-
 #include "kinetic/nonblocking_packet_service_interface.h"
 #include "kinetic/connection_options.h"
 #include "kinetic/hmac_provider.h"

--- a/valgrind_linux.supp
+++ b/valgrind_linux.supp
@@ -7,3 +7,20 @@
    fun:_GLOBAL__sub_I__ZN3fLB17FLAGS_logtostderrE
    ...
 }
+{
+   Ignore OpenSSL malloc
+   Memcheck:Leak
+   fun:malloc
+   fun:CRYPTO_malloc
+   ...
+   obj:*libcrypto*
+}
+
+{
+   Ignore OpenSSL realloc
+   Memcheck:Leak
+   fun:realloc
+   fun:CRYPTO_realloc
+   ...
+   obj:*libcrypto*
+}


### PR DESCRIPTION
This should take care of existing build and linker issues. 

Standard OpenSSL and Protobuf libraries are no longer statically linked into the kinetic library but are normal dependencies. Removed dependency on gtest / gmock when not building the test system. Added cmake options to control linking of glog and gflag libraries and optionally handle openssl thread safety in the client. 

Removed some historical (now unused?) build features to simplify the build process, will re-add if anybody has demand for a feature.